### PR TITLE
fix: lockfile out of date

### DIFF
--- a/nix/modules/lib/oci.nix
+++ b/nix/modules/lib/oci.nix
@@ -310,8 +310,10 @@ in
         args:
         let
           oci = args.perSystemConfig.containers.${args.containerId};
+          # Safely access installNix with a default value
+          installNix = oci.installNix or false;
         in
-        if oci.installNix then cfg.mkNixOCI args else cfg.mkSimpleOCI args;
+        if installNix then cfg.mkNixOCI args else cfg.mkSimpleOCI args;
     };
     mkSimpleOCI = mkOption {
       description = "A function to build simple container";
@@ -320,9 +322,16 @@ in
         args:
         let
           oci = args.perSystemConfig.containers.${args.containerId};
+          # Calculate full container name with registry prefix if provided
+          fullName =
+            if oci.registry != null && oci.registry != "" then
+              "${oci.registry}/${oci.name}"
+            else
+              oci.name;
         in
         (args.perSystemConfig.packages.nix2container.buildImage {
-          inherit (oci) tag name;
+          inherit (oci) tag;
+          name = fullName;
           # NOTE: here we can't use mkIf because fromImage with empty value require an empty string
 
           fromImage =
@@ -360,9 +369,16 @@ in
         args:
         let
           oci = args.perSystemConfig.containers.${args.containerId};
+          # Calculate full container name with registry prefix if provided
+          fullName =
+            if oci.registry != null && oci.registry != "" then
+              "${oci.registry}/${oci.name}"
+            else
+              oci.name;
         in
         args.perSystemConfig.packages.nix2container.buildImage {
-          inherit (oci) name tag;
+          inherit (oci) tag;
+          name = fullName;
           initializeNixDatabase = true;
           copyToRoot = [
             # TODO: add mkNixRoot function to build root with nix shadow setup

--- a/nix/modules/per-system/containers.nix
+++ b/nix/modules/per-system/containers.nix
@@ -324,6 +324,16 @@ in
                     defaultText = lib.literalExpression "cfg.oci.lib.mkOCIName { inherit package fromImage; }";
                     example = "my-app";
                   };
+                  registry = mkOption {
+                    type = types.nullOr types.str;
+                    description = ''
+                      Container registry prefix (e.g., "ghcr.io/my-org" or "my-registry.io/project").
+                      If set, the full container name will be "registry/name".
+                      If null or empty string, no registry prefix will be added.
+                    '';
+                    default = null;
+                    example = "ghcr.io/my-org";
+                  };
                   user = mkOption {
                     type = types.nullOr types.str;
                     description = "The user to run the container as. If null, will be automatically determined based on isRoot setting.";

--- a/tests/end-to-end/default/flake.lock
+++ b/tests/end-to-end/default/flake.lock
@@ -23,34 +23,16 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1736143030,
-        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
+        "lastModified": 1756770412,
+        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "rev": "4524271976b625a4a605beefd893f270620fd751",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -58,31 +40,36 @@
       "inputs": {
         "flake-parts": "flake-parts_2",
         "nix2container": "nix2container",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-7ZglU6uaKoz+0P3wZbxkFDnHYhoLYh1kQ7J62NCWa1Y=",
-        "path": "/nix/store/ag0fbg05pf3qigrvkfmagjwgfwkw0k4m-source",
-        "type": "path"
+        "lastModified": 1762128097,
+        "narHash": "sha256-j6IM1B3gmZx1vBZi0p41BaemJVp+r8ycGDJd6C1yfms=",
+        "owner": "Dauliac",
+        "repo": "nix-oci",
+        "rev": "ff0c5db7a3caa6587b7ed1b5c0289eaf0d3ab4f4",
+        "type": "github"
       },
       "original": {
-        "path": "/nix/store/ag0fbg05pf3qigrvkfmagjwgfwkw0k4m-source",
-        "type": "path"
+        "owner": "Dauliac",
+        "repo": "nix-oci",
+        "type": "github"
       }
     },
     "nix2container": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nix-oci",
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1730479402,
-        "narHash": "sha256-79NLeNjpCa4mSasmFsE3QA6obURezF0TUO5Pm+1daog=",
+        "lastModified": 1752002763,
+        "narHash": "sha256-JYAkdZvpdSx9GUoHPArctYMypSONob4DYKRkOubUWtY=",
         "owner": "nlewo",
         "repo": "nix2container",
-        "rev": "5fb215a1564baa74ce04ad7f903d94ad6617e17a",
+        "rev": "4f2437f6a1844b843b380d483087ae6d461240ee",
         "type": "github"
       },
       "original": {
@@ -93,15 +80,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712920918,
-        "narHash": "sha256-1yxFvUcJfUphK9V91KufIQom7gCsztza0H4Rz2VCWUU=",
-        "owner": "NixOS",
+        "lastModified": 1758035966,
+        "narHash": "sha256-qqIJ3yxPiB0ZQTT9//nFGQYn8X/PBoJbofA7hRKZnmE=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "92323443a56f4e9fc4e4b712e3119f66d0969297",
+        "rev": "8d4ddb19d03c65a36ad8d189d001dc32ffb0306b",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
+        "owner": "nixos",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -120,49 +108,20 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1735774519,
-        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1736344531,
-        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1735554305,
-        "narHash": "sha256-zExSA1i/b+1NMRhGGLtNfFGXgLtgo+dcuzHzaWA6w3Q=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "0e82ab234249d8eee3e8c91437802b32c74bb3fd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
       "locked": {
         "lastModified": 1737062831,
         "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
@@ -182,34 +141,22 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "nix-oci": "nix-oci",
-        "nixpkgs": "nixpkgs_4"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
+        "nixpkgs": "nixpkgs_2"
       }
     },
     "treefmt-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": [
+          "nix-oci",
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1736154270,
-        "narHash": "sha256-p2r8xhQZ3TYIEKBoiEhllKWQqWNJNoT9v64Vmg4q8Zw=",
+        "lastModified": 1756662192,
+        "narHash": "sha256-F1oFfV51AE259I85av+MAia221XwMHCOtZCMcZLK2Jk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "13c913f5deb3a5c08bb810efd89dc8cb24dd968b",
+        "rev": "1aabc6c05ccbcbf4a635fb7a90400e44282f61c4",
         "type": "github"
       },
       "original": {

--- a/tests/end-to-end/main.bats
+++ b/tests/end-to-end/main.bats
@@ -56,6 +56,6 @@
   git init
   run nix flake init -t "$repo_dir"
   [ "$status" -eq 0 ]
-  run nix flake show
+  run nix flake show --override-input nix-oci "path:$repo_dir"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Hello,

I noticed that the template flake.lock (from `nix flake init -t github:Dauliac/nix-oci`) has not been kept up-to-date with the flake inputs. 

It looks like the history has been squashed so I can't pinpoint the guilty commit