### PR TITLE
fix: support documentation generation

### DIFF
--- a/nix/modules/oci/containers/perContainer.nix
+++ b/nix/modules/oci/containers/perContainer.nix
@@ -89,6 +89,7 @@ in
               config._containerName = lib.mkDefault containerName;
             }
           );
+          default = { };
           description = ''
             Per-container module definition.
 

--- a/nix/modules/oci/outputs/apps.nix
+++ b/nix/modules/oci/outputs/apps.nix
@@ -20,6 +20,7 @@ in
         type = types.attrsOf types.attrs;
         description = "OCI-related apps that can be exposed as flake outputs.";
         readOnly = true;
+        defaultText = lib.literalMD "Apps for security scanning, SBOM generation, validation, and multi-arch builds, derived from [`oci.containers`](#opt-perSystem.oci.containers).";
         default =
           let
             hasExternalDependencies = any (containerConfig: containerConfig.fromImage.enabled) (


### PR DESCRIPTION
Add default to perContainer so it has a value when accessed during doc generation. Add defaultText to oci.flake.apps so its default isn't evaluated during doc generation; the default depends on variables like `system` that are not statically known.